### PR TITLE
fix: exclude zero-spend (skipped) runs from token-optimizer AIC ranking

### DIFF
--- a/.github/workflows/agentic-token-optimizer.md
+++ b/.github/workflows/agentic-token-optimizer.md
@@ -69,6 +69,7 @@ steps:
         top_workflows: (
           [.runs[]
             | select(.status == "completed")
+            | select((.aic // 0) > 0)
             | {
                 workflow_name: .workflow_name,
                 ai_credits: (.aic // 0),

--- a/workflows/agentic-token-optimizer.md
+++ b/workflows/agentic-token-optimizer.md
@@ -69,6 +69,7 @@ steps:
         top_workflows: (
           [.runs[]
             | select(.status == "completed")
+            | select((.aic // 0) > 0)
             | {
                 workflow_name: .workflow_name,
                 ai_credits: (.aic // 0),


### PR DESCRIPTION
## Problem

The `Aggregate top workflows by AIC usage` step in `workflows/agentic-token-optimizer.md` keeps **every** `completed` run, including runs whose agent **skipped** (activation/preconditions) and therefore consumed **0 AIC**. Those zero-spend runs:

- pad `run_count` for skip-heavy workflows,
- dilute `avg_ai_credits` (the 0s drag the average down), and
- can surface **never-spent** workflows into the top-10 that drives target selection.

High-frequency, event-driven workflows (e.g. label/PR-triggered) are exactly this case — many `completed` runs, agent skipped on most.

Full write-up in #120. Distinct from (but compounding) the self-targeting guard in #119 / #121.

## Fix

```diff
 [.runs[]
   | select(.status == "completed")
+  | select((.aic // 0) > 0)
   | { workflow_name, ai_credits: (.aic // 0), ... }
 ]
```

A "top workflows **by AIC spend**" ranking should only count runs that actually spent AIC. Applied to both `workflows/` (template) and `.github/workflows/` (active) copies.

## ⚠️ Compiler-version dependency — please read before merging

This is only safe once the compiler reliably computes AIC. On **gh-aw < v0.79.4** — including **v0.72.1**, which this repo currently pins — the Copilot-engine **0-AIC bug** is present (provider `github_models` not normalized; fixed in **v0.79.4** via github/gh-aw#38314, with #38364/#38327/#38353/#38412). There, genuinely-expensive Copilot runs can report `aic == 0`, so this filter would drop **real spend**.

**Recommendation:** pair this with / gate it on bumping these workflows' compiler to **≥ v0.79.4**. Once there, `aic == 0` reliably means "agent skipped / no consumption" and the filter is correct. We run it in production on v0.79.4.

## Notes

- **Source `.md` only** — regenerate `.lock.yml` in-repo (fork-built locks carry repo-scoped cron jitter / differing action-pin resolution).
- Validated `gh aw compile --validate --no-emit` (v0.72.1): 0 errors, 0 warnings.
- Touches a different region of the file than #121, so the two are independent; if #121 merges first this still applies cleanly.

Fixes #120

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>