### PR TITLE
fix: fetch AIC logs per workflow to avoid truncation in busy repos

### DIFF
--- a/.github/workflows/agentic-token-audit.lock.yml
+++ b/.github/workflows/agentic-token-audit.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"a4b06c24463fb7c45698b1f55812de418f28b1b1dc347d4560bc9f9d95e57d55","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4a41c3edd8a3fb119d464ec53a09afac38215cacc41e4814d76d3f62887f0111","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"alpine:latest","digest":"sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11","pinned_image":"alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11"},{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41","digest":"sha256:cb2b565d070116d4b67e355775340528b5a2c3cb18b2c9049638bcc2df681770","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41@sha256:cb2b565d070116d4b67e355775340528b5a2c3cb18b2c9049638bcc2df681770"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41","digest":"sha256:fadd0de387209f69a9a7a1b8722bb5e7fdfb80ba9749a5c60f0e4cd7582a74d0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41@sha256:fadd0de387209f69a9a7a1b8722bb5e7fdfb80ba9749a5c60f0e4cd7582a74d0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41","digest":"sha256:1260445d25968dbf3ae70143964177a0e5914cf2ce07a6117f7d3caec6c3e3c4","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41@sha256:1260445d25968dbf3ae70143964177a0e5914cf2ce07a6117f7d3caec6c3e3c4"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -186,24 +186,24 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_9472b82cb762629a_EOF'
+          cat << 'GH_AW_PROMPT_5cf03e52b2fbd626_EOF'
           <system>
-          GH_AW_PROMPT_9472b82cb762629a_EOF
+          GH_AW_PROMPT_5cf03e52b2fbd626_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/agentic_workflows_guide.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9472b82cb762629a_EOF'
+          cat << 'GH_AW_PROMPT_5cf03e52b2fbd626_EOF'
           <safe-output-tools>
           Tools: create_issue, upload_asset(max:5), missing_tool, missing_data, noop
           
           upload_asset: provide a file path; returns a URL; assets are published after the workflow completes (safeoutputs).
           </safe-output-tools>
-          GH_AW_PROMPT_9472b82cb762629a_EOF
+          GH_AW_PROMPT_5cf03e52b2fbd626_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_9472b82cb762629a_EOF'
+          cat << 'GH_AW_PROMPT_5cf03e52b2fbd626_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -232,12 +232,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_9472b82cb762629a_EOF
+          GH_AW_PROMPT_5cf03e52b2fbd626_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9472b82cb762629a_EOF'
+          cat << 'GH_AW_PROMPT_5cf03e52b2fbd626_EOF'
           </system>
           {{#runtime-import .github/workflows/agentic-token-audit.md}}
-          GH_AW_PROMPT_9472b82cb762629a_EOF
+          GH_AW_PROMPT_5cf03e52b2fbd626_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -397,7 +397,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Download agentic workflow logs
-        run: "set -euo pipefail\nmkdir -p /tmp/gh-aw/token-audit\n\n# Download last 24 hours of agentic workflow logs as JSON\n# Allow partial results — gh aw logs streams incrementally, so even if\n# it hits an API rate limit partway through, the JSON written so far is\n# still valid and should be processed by the agent.\nLOGS_EXIT=0\ngh aw logs \\\n  --start-date -1d \\\n  --json \\\n  -c 100 \\\n  > /tmp/gh-aw/token-audit/workflow-logs.json || LOGS_EXIT=$?\n\nif [ -s /tmp/gh-aw/token-audit/workflow-logs.json ]; then\n  TOTAL=$(jq '.runs | length' /tmp/gh-aw/token-audit/workflow-logs.json)\n  echo \"✅ Downloaded $TOTAL agentic workflow runs (last 24 hours)\"\n  if [ \"$LOGS_EXIT\" -ne 0 ]; then\n    echo \"⚠️ gh aw logs exited with code $LOGS_EXIT (partial results — likely API rate limit)\"\n  fi\nelse\n  echo \"❌ No log data downloaded (exit code $LOGS_EXIT)\"\n  echo '{\"runs\":[],\"summary\":{}}' > /tmp/gh-aw/token-audit/workflow-logs.json\nfi\n"
+        run: "set -euo pipefail\nmkdir -p /tmp/gh-aw/token-audit\nPARTS_DIR=/tmp/gh-aw/token-audit/log-parts\nmkdir -p \"$PARTS_DIR\"\n\n# Fetch logs per workflow to avoid repo-wide pagination truncation in\n# high-CI-volume repositories.\nFOUND_WORKFLOW=0\nfor workflow in .github/workflows/*.md; do\n  [ -f \"$workflow\" ] || continue\n\n  WORKFLOW_ID=$(sed -n 's/^tracker-id:[[:space:]]*//p' \"$workflow\" | head -n 1 | tr -d '\\r' | sed 's/[[:space:]]*$//')\n  [ -n \"$WORKFLOW_ID\" ] || continue\n\n  FOUND_WORKFLOW=1\n  SAFE_WORKFLOW_ID=$(printf '%s' \"$WORKFLOW_ID\" | tr -cs 'A-Za-z0-9._-' '_')\n  PART_FILE=\"$PARTS_DIR/$SAFE_WORKFLOW_ID.json\"\n  PART_EXIT=0\n  gh aw logs \"$WORKFLOW_ID\" \\\n    --start-date -1d \\\n    --json \\\n    -c 100 \\\n    > \"$PART_FILE\" || PART_EXIT=$?\n\n  if ! jq -e . \"$PART_FILE\" >/dev/null 2>&1; then\n    echo \"⚠️ $WORKFLOW_ID: invalid log JSON (exit code $PART_EXIT)\"\n    rm -f \"$PART_FILE\"\n    continue\n  fi\n\n  COUNT=$(jq '(.runs // []) | length' \"$PART_FILE\")\n  if [ \"$COUNT\" -gt 0 ]; then\n    echo \"✅ $WORKFLOW_ID: downloaded $COUNT runs (exit code $PART_EXIT)\"\n  else\n    echo \"⚠️ $WORKFLOW_ID: no log data (exit code $PART_EXIT)\"\n    rm -f \"$PART_FILE\"\n  fi\ndone\n\nif [ \"$FOUND_WORKFLOW\" -eq 1 ] && ls \"$PARTS_DIR\"/*.json >/dev/null 2>&1; then\n  jq -s '\n    (map(.runs // []) | add // [] | unique_by(.run_id)) as $runs |\n    {\n      summary: {\n        total_runs: ($runs | length),\n        total_tokens: ($runs | map(.token_usage // 0) | add // 0),\n        total_aic: ($runs | map(.aic // 0) | add // 0)\n      },\n      runs: $runs\n    }\n  ' \"$PARTS_DIR\"/*.json > /tmp/gh-aw/token-audit/workflow-logs.json\n  TOTAL=$(jq '.runs | length' /tmp/gh-aw/token-audit/workflow-logs.json)\n  echo \"✅ Downloaded $TOTAL agentic workflow runs (last 24 hours)\"\nelse\n  if [ \"$FOUND_WORKFLOW\" -eq 0 ]; then\n    echo \"⚠️ No agentic workflow sources found under .github/workflows\"\n  fi\n  echo '{\"runs\":[],\"summary\":{}}' > /tmp/gh-aw/token-audit/workflow-logs.json\nfi\n"
 
       # Repo memory git-based storage configuration from frontmatter processed below
       - name: Clone repo-memory branch (default)
@@ -505,9 +505,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_3b6ca9f5acfde28d_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_96aadebda21ac3d1_EOF
           {"create_issue":{"close_older_issues":true,"expires":72,"max":1,"title_prefix":"[agentic-token-audit] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":102400,"max_patch_size":51200}]},"report_incomplete":{},"upload_asset":{"allowed-exts":[".png",".jpg",".jpeg",".svg"],"branch":"assets/${GITHUB_WORKFLOW}","max":5,"max-size":10240}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_3b6ca9f5acfde28d_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_96aadebda21ac3d1_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -721,7 +721,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_8ff2b9231c74daa4_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_f71fd93db367b941_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "agenticworkflows": {
@@ -783,7 +783,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_8ff2b9231c74daa4_EOF
+          GH_AW_MCP_CONFIG_f71fd93db367b941_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/agentic-token-audit.md
+++ b/.github/workflows/agentic-token-audit.md
@@ -59,11 +59,12 @@ steps:
       for workflow in .github/workflows/*.md; do
         [ -f "$workflow" ] || continue
 
-        WORKFLOW_ID=$(sed -n 's/^tracker-id:[[:space:]]*//p' "$workflow" | head -n 1)
+        WORKFLOW_ID=$(sed -n 's/^tracker-id:[[:space:]]*//p' "$workflow" | head -n 1 | tr -d '\r' | sed 's/[[:space:]]*$//')
         [ -n "$WORKFLOW_ID" ] || continue
 
         FOUND_WORKFLOW=1
-        PART_FILE="$PARTS_DIR/$WORKFLOW_ID.json"
+        SAFE_WORKFLOW_ID=$(printf '%s' "$WORKFLOW_ID" | tr -cs 'A-Za-z0-9._-' '_')
+        PART_FILE="$PARTS_DIR/$SAFE_WORKFLOW_ID.json"
         PART_EXIT=0
         gh aw logs "$WORKFLOW_ID" \
           --start-date -1d \

--- a/.github/workflows/agentic-token-audit.md
+++ b/.github/workflows/agentic-token-audit.md
@@ -88,8 +88,17 @@ steps:
       done
 
       if [ "$FOUND_WORKFLOW" -eq 1 ] && ls "$PARTS_DIR"/*.json >/dev/null 2>&1; then
-        jq -s '{summary: {}, runs: (map(.runs // []) | add | unique_by(.run_id))}' \
-          "$PARTS_DIR"/*.json > /tmp/gh-aw/token-audit/workflow-logs.json
+        jq -s '
+          (map(.runs // []) | add // [] | unique_by(.run_id)) as $runs |
+          {
+            summary: {
+              total_runs: ($runs | length),
+              total_tokens: ($runs | map(.token_usage // 0) | add // 0),
+              total_aic: ($runs | map(.aic // 0) | add // 0)
+            },
+            runs: $runs
+          }
+        ' "$PARTS_DIR"/*.json > /tmp/gh-aw/token-audit/workflow-logs.json
         TOTAL=$(jq '.runs | length' /tmp/gh-aw/token-audit/workflow-logs.json)
         echo "✅ Downloaded $TOTAL agentic workflow runs (last 24 hours)"
       else

--- a/.github/workflows/agentic-token-audit.md
+++ b/.github/workflows/agentic-token-audit.md
@@ -50,26 +50,51 @@ steps:
     run: |
       set -euo pipefail
       mkdir -p /tmp/gh-aw/token-audit
+      PARTS_DIR=/tmp/gh-aw/token-audit/log-parts
+      mkdir -p "$PARTS_DIR"
 
-      # Download last 24 hours of agentic workflow logs as JSON
-      # Allow partial results — gh aw logs streams incrementally, so even if
-      # it hits an API rate limit partway through, the JSON written so far is
-      # still valid and should be processed by the agent.
-      LOGS_EXIT=0
-      gh aw logs \
-        --start-date -1d \
-        --json \
-        -c 100 \
-        > /tmp/gh-aw/token-audit/workflow-logs.json || LOGS_EXIT=$?
+      # Fetch logs per workflow to avoid repo-wide pagination truncation in
+      # high-CI-volume repositories.
+      FOUND_WORKFLOW=0
+      for workflow in .github/workflows/*.md; do
+        [ -f "$workflow" ] || continue
 
-      if [ -s /tmp/gh-aw/token-audit/workflow-logs.json ]; then
+        WORKFLOW_ID=$(sed -n 's/^tracker-id:[[:space:]]*//p' "$workflow" | head -n 1)
+        [ -n "$WORKFLOW_ID" ] || continue
+
+        FOUND_WORKFLOW=1
+        PART_FILE="$PARTS_DIR/$WORKFLOW_ID.json"
+        PART_EXIT=0
+        gh aw logs "$WORKFLOW_ID" \
+          --start-date -1d \
+          --json \
+          -c 100 \
+          > "$PART_FILE" || PART_EXIT=$?
+
+        if ! jq -e . "$PART_FILE" >/dev/null 2>&1; then
+          echo "⚠️ $WORKFLOW_ID: invalid log JSON (exit code $PART_EXIT)"
+          rm -f "$PART_FILE"
+          continue
+        fi
+
+        COUNT=$(jq '(.runs // []) | length' "$PART_FILE")
+        if [ "$COUNT" -gt 0 ]; then
+          echo "✅ $WORKFLOW_ID: downloaded $COUNT runs (exit code $PART_EXIT)"
+        else
+          echo "⚠️ $WORKFLOW_ID: no log data (exit code $PART_EXIT)"
+          rm -f "$PART_FILE"
+        fi
+      done
+
+      if [ "$FOUND_WORKFLOW" -eq 1 ] && ls "$PARTS_DIR"/*.json >/dev/null 2>&1; then
+        jq -s '{summary: {}, runs: (map(.runs // []) | add | unique_by(.run_id))}' \
+          "$PARTS_DIR"/*.json > /tmp/gh-aw/token-audit/workflow-logs.json
         TOTAL=$(jq '.runs | length' /tmp/gh-aw/token-audit/workflow-logs.json)
         echo "✅ Downloaded $TOTAL agentic workflow runs (last 24 hours)"
-        if [ "$LOGS_EXIT" -ne 0 ]; then
-          echo "⚠️ gh aw logs exited with code $LOGS_EXIT (partial results — likely API rate limit)"
-        fi
       else
-        echo "❌ No log data downloaded (exit code $LOGS_EXIT)"
+        if [ "$FOUND_WORKFLOW" -eq 0 ]; then
+          echo "⚠️ No agentic workflow sources found under .github/workflows"
+        fi
         echo '{"runs":[],"summary":{}}' > /tmp/gh-aw/token-audit/workflow-logs.json
       fi
 timeout-minutes: 25

--- a/.github/workflows/agentic-token-optimizer.lock.yml
+++ b/.github/workflows/agentic-token-optimizer.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6575adb2a95e4d872f1047f1b8768d20038954d7260f149d2e9b68c8ed1a0c71","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d726a19fbf99aff6811417f8693963f5f73e5bd1ab46d20792eafcd345ca8407","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41","digest":"sha256:cb2b565d070116d4b67e355775340528b5a2c3cb18b2c9049638bcc2df681770","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41@sha256:cb2b565d070116d4b67e355775340528b5a2c3cb18b2c9049638bcc2df681770"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41","digest":"sha256:fadd0de387209f69a9a7a1b8722bb5e7fdfb80ba9749a5c60f0e4cd7582a74d0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41@sha256:fadd0de387209f69a9a7a1b8722bb5e7fdfb80ba9749a5c60f0e4cd7582a74d0"},{"image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.25.41","digest":"sha256:62171f2fa508667b8b0a9e096f826983f312e3da0ce894f80c0f83a875af60fe","pinned_image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.25.41@sha256:62171f2fa508667b8b0a9e096f826983f312e3da0ce894f80c0f83a875af60fe"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41","digest":"sha256:1260445d25968dbf3ae70143964177a0e5914cf2ce07a6117f7d3caec6c3e3c4","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41@sha256:1260445d25968dbf3ae70143964177a0e5914cf2ce07a6117f7d3caec6c3e3c4"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -184,21 +184,21 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_d789fdfb9e89a466_EOF'
+          cat << 'GH_AW_PROMPT_d354ada9927ab237_EOF'
           <system>
-          GH_AW_PROMPT_d789fdfb9e89a466_EOF
+          GH_AW_PROMPT_d354ada9927ab237_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_d789fdfb9e89a466_EOF'
+          cat << 'GH_AW_PROMPT_d354ada9927ab237_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_d789fdfb9e89a466_EOF
+          GH_AW_PROMPT_d354ada9927ab237_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_d789fdfb9e89a466_EOF'
+          cat << 'GH_AW_PROMPT_d354ada9927ab237_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -227,12 +227,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_d789fdfb9e89a466_EOF
+          GH_AW_PROMPT_d354ada9927ab237_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/cli_proxy_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_d789fdfb9e89a466_EOF'
+          cat << 'GH_AW_PROMPT_d354ada9927ab237_EOF'
           </system>
           {{#runtime-import .github/workflows/agentic-token-optimizer.md}}
-          GH_AW_PROMPT_d789fdfb9e89a466_EOF
+          GH_AW_PROMPT_d354ada9927ab237_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -382,7 +382,7 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Download recent agentic workflow logs
-        run: "set -euo pipefail\nmkdir -p /tmp/gh-aw/token-audit\n\necho \"📥 Downloading agentic workflow logs (last 7 days)...\"\n\nLOGS_EXIT=0\ngh aw logs \\\n  --start-date -7d \\\n  --json \\\n  -c 50 \\\n  > /tmp/gh-aw/token-audit/all-runs.json || LOGS_EXIT=$?\n\nif [ -s /tmp/gh-aw/token-audit/all-runs.json ]; then\n  TOTAL=$(jq '.runs | length' /tmp/gh-aw/token-audit/all-runs.json)\n  echo \"✅ Downloaded $TOTAL agentic workflow runs (last 7 days)\"\n  if [ \"$LOGS_EXIT\" -ne 0 ]; then\n    echo \"⚠️ gh aw logs exited with code $LOGS_EXIT (partial results — likely API rate limit)\"\n  fi\nelse\n  echo \"❌ No log data downloaded (exit code $LOGS_EXIT)\"\n  echo '{\"runs\":[],\"summary\":{}}' > /tmp/gh-aw/token-audit/all-runs.json\nfi\n"
+        run: "set -euo pipefail\nmkdir -p /tmp/gh-aw/token-audit\nPARTS_DIR=/tmp/gh-aw/token-audit/log-parts\nmkdir -p \"$PARTS_DIR\"\n\necho \"📥 Downloading agentic workflow logs (last 7 days)...\"\n\nFOUND_WORKFLOW=0\nfor workflow in .github/workflows/*.md; do\n  [ -f \"$workflow\" ] || continue\n\n  WORKFLOW_ID=$(sed -n 's/^tracker-id:[[:space:]]*//p' \"$workflow\" | head -n 1 | tr -d '\\r' | sed 's/[[:space:]]*$//')\n  [ -n \"$WORKFLOW_ID\" ] || continue\n\n  FOUND_WORKFLOW=1\n  SAFE_WORKFLOW_ID=$(printf '%s' \"$WORKFLOW_ID\" | tr -cs 'A-Za-z0-9._-' '_')\n  PART_FILE=\"$PARTS_DIR/$SAFE_WORKFLOW_ID.json\"\n  PART_EXIT=0\n  gh aw logs \"$WORKFLOW_ID\" \\\n    --start-date -7d \\\n    --json \\\n    -c 50 \\\n    > \"$PART_FILE\" || PART_EXIT=$?\n\n  if ! jq -e . \"$PART_FILE\" >/dev/null 2>&1; then\n    echo \"⚠️ $WORKFLOW_ID: invalid log JSON (exit code $PART_EXIT)\"\n    rm -f \"$PART_FILE\"\n    continue\n  fi\n\n  COUNT=$(jq '(.runs // []) | length' \"$PART_FILE\")\n  if [ \"$COUNT\" -gt 0 ]; then\n    echo \"✅ $WORKFLOW_ID: downloaded $COUNT runs (exit code $PART_EXIT)\"\n  else\n    echo \"⚠️ $WORKFLOW_ID: no log data (exit code $PART_EXIT)\"\n    rm -f \"$PART_FILE\"\n  fi\ndone\n\nif [ \"$FOUND_WORKFLOW\" -eq 1 ] && ls \"$PARTS_DIR\"/*.json >/dev/null 2>&1; then\n  jq -s '\n    (map(.runs // []) | add // [] | unique_by(.run_id)) as $runs |\n    {\n      summary: {\n        total_runs: ($runs | length),\n        total_tokens: ($runs | map(.token_usage // 0) | add // 0),\n        total_aic: ($runs | map(.aic // 0) | add // 0)\n      },\n      runs: $runs\n    }\n  ' \"$PARTS_DIR\"/*.json > /tmp/gh-aw/token-audit/all-runs.json\n  TOTAL=$(jq '.runs | length' /tmp/gh-aw/token-audit/all-runs.json)\n  echo \"✅ Downloaded $TOTAL agentic workflow runs (last 7 days)\"\nelse\n  if [ \"$FOUND_WORKFLOW\" -eq 0 ]; then\n    echo \"⚠️ No agentic workflow sources found under .github/workflows\"\n  fi\n  echo '{\"runs\":[],\"summary\":{}}' > /tmp/gh-aw/token-audit/all-runs.json\nfi\n"
       - name: Aggregate top workflows by AIC usage
         run: "set -euo pipefail\nmkdir -p /tmp/gh-aw/token-audit\n\njq '{\n  generated_at: (now | todateiso8601),\n  window_days: 7,\n  top_workflows: (\n    [.runs[]\n      | select(.status == \"completed\")\n      | {\n          workflow_name: .workflow_name,\n          ai_credits: (.aic // 0),\n          tokens: (.token_usage // 0),\n          turns: (.turns // 0),\n          action_minutes: (.action_minutes // 0)\n        }\n    ]\n    | group_by(.workflow_name)\n    | map({\n        workflow_name: .[0].workflow_name,\n        run_count: length,\n        total_ai_credits: (map(.ai_credits) | add),\n        avg_ai_credits: ((map(.ai_credits) | add) / length),\n        total_tokens: (map(.tokens) | add),\n        avg_tokens: ((map(.tokens) | add) / length),\n        total_turns: (map(.turns) | add),\n        total_action_minutes: (map(.action_minutes) | add)\n      })\n    | sort_by(.total_ai_credits)\n    | reverse\n    | .[:10]\n  )\n}' /tmp/gh-aw/token-audit/all-runs.json > /tmp/gh-aw/token-audit/top-workflows.json\n\necho \"✅ Generated top workflow summary at /tmp/gh-aw/token-audit/top-workflows.json\"\njq '.top_workflows' /tmp/gh-aw/token-audit/top-workflows.json\n"
       - name: Load optimization history
@@ -464,9 +464,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_6933ed503367a1e3_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_19029e4dd3a2a298_EOF'
           {"create_issue":{"close_older_issues":true,"expires":168,"max":1,"title_prefix":"[agentic-token-optimizer] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":102400,"max_patch_size":51200}]},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_6933ed503367a1e3_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_19029e4dd3a2a298_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -663,7 +663,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_785ae819de11c730_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_29a6df1139fc2424_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "safeoutputs": {
@@ -688,7 +688,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_785ae819de11c730_EOF
+          GH_AW_MCP_CONFIG_29a6df1139fc2424_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/agentic-token-optimizer.md
+++ b/.github/workflows/agentic-token-optimizer.md
@@ -75,8 +75,17 @@ steps:
       done
 
       if [ "$FOUND_WORKFLOW" -eq 1 ] && ls "$PARTS_DIR"/*.json >/dev/null 2>&1; then
-        jq -s '{summary: {}, runs: (map(.runs // []) | add | unique_by(.run_id))}' \
-          "$PARTS_DIR"/*.json > /tmp/gh-aw/token-audit/all-runs.json
+        jq -s '
+          (map(.runs // []) | add // [] | unique_by(.run_id)) as $runs |
+          {
+            summary: {
+              total_runs: ($runs | length),
+              total_tokens: ($runs | map(.token_usage // 0) | add // 0),
+              total_aic: ($runs | map(.aic // 0) | add // 0)
+            },
+            runs: $runs
+          }
+        ' "$PARTS_DIR"/*.json > /tmp/gh-aw/token-audit/all-runs.json
         TOTAL=$(jq '.runs | length' /tmp/gh-aw/token-audit/all-runs.json)
         echo "✅ Downloaded $TOTAL agentic workflow runs (last 7 days)"
       else

--- a/.github/workflows/agentic-token-optimizer.md
+++ b/.github/workflows/agentic-token-optimizer.md
@@ -37,24 +37,51 @@ steps:
     run: |
       set -euo pipefail
       mkdir -p /tmp/gh-aw/token-audit
+      PARTS_DIR=/tmp/gh-aw/token-audit/log-parts
+      mkdir -p "$PARTS_DIR"
 
       echo "📥 Downloading agentic workflow logs (last 7 days)..."
 
-      LOGS_EXIT=0
-      gh aw logs \
-        --start-date -7d \
-        --json \
-        -c 50 \
-        > /tmp/gh-aw/token-audit/all-runs.json || LOGS_EXIT=$?
+      FOUND_WORKFLOW=0
+      for workflow in .github/workflows/*.md; do
+        [ -f "$workflow" ] || continue
 
-      if [ -s /tmp/gh-aw/token-audit/all-runs.json ]; then
+        WORKFLOW_ID=$(sed -n 's/^tracker-id:[[:space:]]*//p' "$workflow" | head -n 1)
+        [ -n "$WORKFLOW_ID" ] || continue
+
+        FOUND_WORKFLOW=1
+        PART_FILE="$PARTS_DIR/$WORKFLOW_ID.json"
+        PART_EXIT=0
+        gh aw logs "$WORKFLOW_ID" \
+          --start-date -7d \
+          --json \
+          -c 50 \
+          > "$PART_FILE" || PART_EXIT=$?
+
+        if ! jq -e . "$PART_FILE" >/dev/null 2>&1; then
+          echo "⚠️ $WORKFLOW_ID: invalid log JSON (exit code $PART_EXIT)"
+          rm -f "$PART_FILE"
+          continue
+        fi
+
+        COUNT=$(jq '(.runs // []) | length' "$PART_FILE")
+        if [ "$COUNT" -gt 0 ]; then
+          echo "✅ $WORKFLOW_ID: downloaded $COUNT runs (exit code $PART_EXIT)"
+        else
+          echo "⚠️ $WORKFLOW_ID: no log data (exit code $PART_EXIT)"
+          rm -f "$PART_FILE"
+        fi
+      done
+
+      if [ "$FOUND_WORKFLOW" -eq 1 ] && ls "$PARTS_DIR"/*.json >/dev/null 2>&1; then
+        jq -s '{summary: {}, runs: (map(.runs // []) | add | unique_by(.run_id))}' \
+          "$PARTS_DIR"/*.json > /tmp/gh-aw/token-audit/all-runs.json
         TOTAL=$(jq '.runs | length' /tmp/gh-aw/token-audit/all-runs.json)
         echo "✅ Downloaded $TOTAL agentic workflow runs (last 7 days)"
-        if [ "$LOGS_EXIT" -ne 0 ]; then
-          echo "⚠️ gh aw logs exited with code $LOGS_EXIT (partial results — likely API rate limit)"
-        fi
       else
-        echo "❌ No log data downloaded (exit code $LOGS_EXIT)"
+        if [ "$FOUND_WORKFLOW" -eq 0 ]; then
+          echo "⚠️ No agentic workflow sources found under .github/workflows"
+        fi
         echo '{"runs":[],"summary":{}}' > /tmp/gh-aw/token-audit/all-runs.json
       fi
 

--- a/.github/workflows/agentic-token-optimizer.md
+++ b/.github/workflows/agentic-token-optimizer.md
@@ -46,11 +46,12 @@ steps:
       for workflow in .github/workflows/*.md; do
         [ -f "$workflow" ] || continue
 
-        WORKFLOW_ID=$(sed -n 's/^tracker-id:[[:space:]]*//p' "$workflow" | head -n 1)
+        WORKFLOW_ID=$(sed -n 's/^tracker-id:[[:space:]]*//p' "$workflow" | head -n 1 | tr -d '\r' | sed 's/[[:space:]]*$//')
         [ -n "$WORKFLOW_ID" ] || continue
 
         FOUND_WORKFLOW=1
-        PART_FILE="$PARTS_DIR/$WORKFLOW_ID.json"
+        SAFE_WORKFLOW_ID=$(printf '%s' "$WORKFLOW_ID" | tr -cs 'A-Za-z0-9._-' '_')
+        PART_FILE="$PARTS_DIR/$SAFE_WORKFLOW_ID.json"
         PART_EXIT=0
         gh aw logs "$WORKFLOW_ID" \
           --start-date -7d \


### PR DESCRIPTION
- Closes  #123

- Replaces repo-wide `gh aw logs --json` collection in the audit and optimizer workflows with per-workflow log collection so high-CI-volume repositories do not lose data when skipped/cancelled-heavy batches cause pagination to stop early.
- Per-workflow collection avoids that failure mode and keeps the fix independent of generated `.lock.yml` artifacts.

- Fixed by:
  - Enumerating authored workflow sources under `.github/workflows/*.md`
  - Extracting each workflow `tracker-id` and fetch `gh aw logs <tracker-id>` independently
  - Merging collected runs into the existing JSON shape and dedupe by `run_id`
  - Computing a minimal merged `summary` from the combined runs
  - Discarding invalid or empty partial JSON results
  - Keeping existing downstream audit and optimizer analysis logic unchanged
